### PR TITLE
Support both password and passwordless auth type for PostgreSQL and MySQL

### DIFF
--- a/cli/azd/internal/repository/infra_confirm.go
+++ b/cli/azd/internal/repository/infra_confirm.go
@@ -72,21 +72,41 @@ func (i *Initializer) infraSpecFromDetect(
 				}
 			}
 
+			authType := scaffold.AuthType(0)
+			selection, err := i.console.Select(ctx, input.ConsoleOptions{
+				Message: "Input the authentication type you want for database:",
+				Options: []string{
+					"Use user assigned managed identity",
+					"Use username and password",
+				},
+			})
+			if err != nil {
+				return scaffold.InfraSpec{}, err
+			}
+			switch selection {
+			case 0:
+				authType = scaffold.AuthType_TOKEN_CREDENTIAL
+			case 1:
+				authType = scaffold.AuthType_PASSWORD
+			default:
+				panic("unhandled selection")
+			}
+
 			switch database {
 			case appdetect.DbMongo:
 				spec.DbCosmosMongo = &scaffold.DatabaseCosmosMongo{
 					DatabaseName: dbName,
 				}
-
 				break dbPrompt
 			case appdetect.DbPostgres:
 				if dbName == "" {
 					i.console.Message(ctx, "Database name is required.")
 					continue
 				}
-
 				spec.DbPostgres = &scaffold.DatabasePostgres{
-					DatabaseName: dbName,
+					DatabaseName:              dbName,
+					AuthUsingManagedIdentity:  authType == scaffold.AuthType_TOKEN_CREDENTIAL,
+					AuthUsingUsernamePassword: authType == scaffold.AuthType_PASSWORD,
 				}
 				break dbPrompt
 			case appdetect.DbMySql:
@@ -95,7 +115,9 @@ func (i *Initializer) infraSpecFromDetect(
 					continue
 				}
 				spec.DbMySql = &scaffold.DatabaseMySql{
-					DatabaseName: dbName,
+					DatabaseName:              dbName,
+					AuthUsingManagedIdentity:  authType == scaffold.AuthType_TOKEN_CREDENTIAL,
+					AuthUsingUsernamePassword: authType == scaffold.AuthType_PASSWORD,
 				}
 				break dbPrompt
 			}
@@ -145,11 +167,15 @@ func (i *Initializer) infraSpecFromDetect(
 				}
 			case appdetect.DbPostgres:
 				serviceSpec.DbPostgres = &scaffold.DatabaseReference{
-					DatabaseName: spec.DbPostgres.DatabaseName,
+					DatabaseName:              spec.DbPostgres.DatabaseName,
+					AuthUsingManagedIdentity:  spec.DbPostgres.AuthUsingManagedIdentity,
+					AuthUsingUsernamePassword: spec.DbPostgres.AuthUsingUsernamePassword,
 				}
 			case appdetect.DbMySql:
 				serviceSpec.DbMySql = &scaffold.DatabaseReference{
-					DatabaseName: spec.DbMySql.DatabaseName,
+					DatabaseName:              spec.DbMySql.DatabaseName,
+					AuthUsingManagedIdentity:  spec.DbPostgres.AuthUsingManagedIdentity,
+					AuthUsingUsernamePassword: spec.DbPostgres.AuthUsingUsernamePassword,
 				}
 			case appdetect.DbRedis:
 				serviceSpec.DbRedis = &scaffold.DatabaseReference{

--- a/cli/azd/internal/repository/infra_confirm.go
+++ b/cli/azd/internal/repository/infra_confirm.go
@@ -174,8 +174,8 @@ func (i *Initializer) infraSpecFromDetect(
 			case appdetect.DbMySql:
 				serviceSpec.DbMySql = &scaffold.DatabaseReference{
 					DatabaseName:              spec.DbMySql.DatabaseName,
-					AuthUsingManagedIdentity:  spec.DbPostgres.AuthUsingManagedIdentity,
-					AuthUsingUsernamePassword: spec.DbPostgres.AuthUsingUsernamePassword,
+					AuthUsingManagedIdentity:  spec.DbMySql.AuthUsingManagedIdentity,
+					AuthUsingUsernamePassword: spec.DbMySql.AuthUsingUsernamePassword,
 				}
 			case appdetect.DbRedis:
 				serviceSpec.DbRedis = &scaffold.DatabaseReference{

--- a/cli/azd/internal/scaffold/spec.go
+++ b/cli/azd/internal/scaffold/spec.go
@@ -26,13 +26,17 @@ type Parameter struct {
 }
 
 type DatabasePostgres struct {
-	DatabaseUser string
-	DatabaseName string
+	DatabaseUser              string
+	DatabaseName              string
+	AuthUsingManagedIdentity  bool
+	AuthUsingUsernamePassword bool
 }
 
 type DatabaseMySql struct {
-	DatabaseUser string
-	DatabaseName string
+	DatabaseUser              string
+	DatabaseName              string
+	AuthUsingManagedIdentity  bool
+	AuthUsingUsernamePassword bool
 }
 
 type DatabaseCosmosMongo struct {
@@ -91,7 +95,9 @@ type ServiceReference struct {
 }
 
 type DatabaseReference struct {
-	DatabaseName string
+	DatabaseName              string
+	AuthUsingManagedIdentity  bool
+	AuthUsingUsernamePassword bool
 }
 
 func containerAppExistsParameter(serviceName string) Parameter {

--- a/cli/azd/resources/scaffold/templates/db-mysql.bicept
+++ b/cli/azd/resources/scaffold/templates/db-mysql.bicept
@@ -81,4 +81,8 @@ resource dbPasswordKey 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
 
 output databaseId string = database.id
 output identityName string = userAssignedIdentity.name
+output databaseHost string = mysqlServer.properties.fullyQualifiedDomainName
+output databaseName string = databaseName
+output databaseUser string = databaseUser
+output databaseConnectionKey string = 'databasePassword'
 {{ end}}

--- a/cli/azd/resources/scaffold/templates/host-containerapp.bicept
+++ b/cli/azd/resources/scaffold/templates/host-containerapp.bicept
@@ -346,7 +346,7 @@ resource appLinkToPostgres 'Microsoft.Resources/deploymentScripts@2023-08-01' = 
   properties: {
     azCliVersion: '2.63.0'
     timeout: 'PT10M'
-    scriptContent: 'apk update; apk add g++; apk add unixodbc-dev; az extension add --name containerapp; az extension add --name serviceconnector-passwordless --upgrade; az containerapp connection create postgres-flexible --connection appLinkToPostgres --source-id ${app.id} --target-id ${postgresDatabaseId} --client-type springBoot --user-identity client-id=${identity.properties.clientId} subs-id=${subscription().subscriptionId} user-object-id=${linkerCreatorIdentity.properties.principalId} -c main --yes; az tag create --resource-id ${app.id} --tags azd-service-name={{.Name}} '
+    scriptContent: 'apk update; apk add g++; apk add unixodbc-dev; az extension add --name containerapp; az extension add --name serviceconnector-passwordless --upgrade; az containerapp connection create postgres-flexible --connection appLinkToPostgres --source-id ${app.id} --target-id ${postgresDatabaseId} --client-type springBoot --user-identity client-id=${identity.properties.clientId} subs-id=${subscription().subscriptionId} user-object-id=${linkerCreatorIdentity.properties.principalId} -c main --yes;'
     cleanupPreference: 'OnSuccess'
     retentionInterval: 'P1D'
   }

--- a/cli/azd/resources/scaffold/templates/host-containerapp.bicept
+++ b/cli/azd/resources/scaffold/templates/host-containerapp.bicept
@@ -52,6 +52,7 @@ param allowedOrigins array
 param exists bool
 @secure()
 param appDefinition object
+param currentTime string = utcNow()
 
 var appSettingsArray = filter(array(appDefinition.settings), i => i.name != '')
 var secrets = map(filter(appSettingsArray, i => i.?secret != null), i => {
@@ -346,6 +347,7 @@ resource appLinkToPostgres 'Microsoft.Resources/deploymentScripts@2023-08-01' = 
   properties: {
     azCliVersion: '2.63.0'
     timeout: 'PT10M'
+    forceUpdateTag: currentTime
     scriptContent: 'apk update; apk add g++; apk add unixodbc-dev; az extension add --name containerapp; az extension add --name serviceconnector-passwordless --upgrade; az containerapp connection create postgres-flexible --connection appLinkToPostgres --source-id ${app.id} --target-id ${postgresDatabaseId} --client-type springBoot --user-identity client-id=${identity.properties.clientId} subs-id=${subscription().subscriptionId} user-object-id=${linkerCreatorIdentity.properties.principalId} -c main --yes;'
     cleanupPreference: 'OnSuccess'
     retentionInterval: 'P1D'
@@ -368,6 +370,7 @@ resource appLinkToMySql 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
   properties: {
     azCliVersion: '2.63.0'
     timeout: 'PT10M'
+    forceUpdateTag: currentTime
     scriptContent: 'apk update; apk add g++; apk add unixodbc-dev; az extension add --name containerapp; az extension add --name serviceconnector-passwordless --upgrade; az containerapp connection create mysql-flexible --connection appLinkToMySql --source-id ${app.id} --target-id ${mysqlDatabaseId} --client-type springBoot --user-identity client-id=${identity.properties.clientId} subs-id=${subscription().subscriptionId} user-object-id=${linkerCreatorIdentity.properties.principalId} mysql-identity-id=${mysqlIdentityName} -c main --yes;'
     cleanupPreference: 'OnSuccess'
     retentionInterval: 'P1D'

--- a/cli/azd/resources/scaffold/templates/host-containerapp.bicept
+++ b/cli/azd/resources/scaffold/templates/host-containerapp.bicept
@@ -11,11 +11,13 @@ param applicationInsightsName string
 @secure()
 param cosmosDbConnectionString string
 {{- end}}
-{{- if .DbPostgres}}
-param postgresDatabaseHost string
-param postgresDatabaseUser string
-param postgresDatabaseName string
+{{- if (and .DbPostgres .DbPostgres.AuthUsingManagedIdentity)}}
 param postgresDatabaseId string
+{{- end}}
+{{- if (and .DbPostgres .DbPostgres.AuthUsingUsernamePassword)}}
+param postgresDatabaseHost string
+param postgresDatabaseName string
+param postgresDatabaseUser string
 @secure()
 param postgresDatabasePassword string
 {{- end}}
@@ -154,7 +156,7 @@ resource app 'Microsoft.App/containerApps@2023-05-02-preview' = {
           value: cosmosDbConnectionString
         }
         {{- end}}
-        {{- if .DbPostgres}}
+        {{- if (and .DbPostgres .DbPostgres.AuthUsingUsernamePassword)}}
         {
           name: 'postgres-db-pass'
           value: postgresDatabasePassword
@@ -188,26 +190,26 @@ resource app 'Microsoft.App/containerApps@2023-05-02-preview' = {
               secretRef: 'azure-cosmos-connection-string'
             }
             {{- end}}
-            {{- if .DbPostgres}}
+            {{- if (and .DbPostgres .DbPostgres.AuthUsingUsernamePassword)}}
             {
               name: 'POSTGRES_HOST'
               value: postgresDatabaseHost
             }
             {
-              name: 'POSTGRES_USERNAME'
-              value: postgresDatabaseUser
+              name: 'POSTGRES_PORT'
+              value: '5432'
             }
             {
               name: 'POSTGRES_DATABASE'
               value: postgresDatabaseName
             }
             {
-              name: 'POSTGRES_PASSWORD'
-              secretRef: 'postgres-db-pass'
+              name: 'POSTGRES_USERNAME'
+              value: postgresDatabaseUser
             }
             {
-              name: 'POSTGRES_PORT'
-              value: '5432'
+              name: 'POSTGRES_PASSWORD'
+              secretRef: 'postgres-db-pass'
             }
             {{- end}}
             {{- if (and .AzureServiceBus .AzureServiceBus.AuthUsingConnectionString)}}
@@ -275,7 +277,7 @@ resource app 'Microsoft.App/containerApps@2023-05-02-preview' = {
     }
   }
 }
-{{- if (or .DbMySql .DbPostgres)}}
+{{- if (or .DbMySql (and .DbPostgres .DbPostgres.AuthUsingManagedIdentity))}}
 
 resource linkerCreatorIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
   name: '${name}-linker-creator-identity'
@@ -315,7 +317,7 @@ resource appLinkToMySql 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
   }
 }
 {{- end}}
-{{- if .DbPostgres}}
+{{- if (and .DbPostgres .DbPostgres.AuthUsingManagedIdentity)}}
 
 resource appLinkToPostgres 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
   dependsOn: [ linkerCreatorRole ]

--- a/cli/azd/resources/scaffold/templates/host-containerapp.bicept
+++ b/cli/azd/resources/scaffold/templates/host-containerapp.bicept
@@ -21,9 +21,16 @@ param postgresDatabaseUser string
 @secure()
 param postgresDatabasePassword string
 {{- end}}
-{{- if .DbMySql}}
+{{- if (and .DbMySql .DbMySql.AuthUsingManagedIdentity)}}
 param mysqlDatabaseId string
 param mysqlIdentityName string
+{{- end}}
+{{- if (and .DbMySql .DbMySql.AuthUsingUsernamePassword)}}
+param mysqlDatabaseHost string
+param mysqlDatabaseName string
+param mysqlDatabaseUser string
+@secure()
+param mysqlDatabasePassword string
 {{- end}}
 {{- if (and .AzureServiceBus .AzureServiceBus.AuthUsingConnectionString)}}
 @secure()
@@ -162,6 +169,12 @@ resource app 'Microsoft.App/containerApps@2023-05-02-preview' = {
           value: postgresDatabasePassword
         }
         {{- end}}
+        {{- if (and .DbMySql .DbMySql.AuthUsingUsernamePassword)}}
+        {
+          name: 'mysql-db-pass'
+          value: mysqlDatabasePassword
+        }
+        {{- end}}
         {{- if (and .AzureServiceBus .AzureServiceBus.AuthUsingConnectionString)}}
         {
           name: 'spring-cloud-azure-servicebus-connection-string'
@@ -210,6 +223,28 @@ resource app 'Microsoft.App/containerApps@2023-05-02-preview' = {
             {
               name: 'POSTGRES_PASSWORD'
               secretRef: 'postgres-db-pass'
+            }
+            {{- end}}
+            {{- if (and .DbMySql .DbMySql.AuthUsingUsernamePassword)}}
+            {
+              name: 'MYSQL_HOST'
+              value: mysqlDatabaseHost
+            }
+            {
+              name: 'MYSQL_PORT'
+              value: '3306'
+            }
+            {
+              name: 'MYSQL_DATABASE'
+              value: mysqlDatabaseName
+            }
+            {
+              name: 'MYSQL_USERNAME'
+              value: mysqlDatabaseUser
+            }
+            {
+              name: 'MYSQL_PASSWORD'
+              secretRef: 'mysql-db-pass'
             }
             {{- end}}
             {{- if (and .AzureServiceBus .AzureServiceBus.AuthUsingConnectionString)}}
@@ -277,7 +312,7 @@ resource app 'Microsoft.App/containerApps@2023-05-02-preview' = {
     }
   }
 }
-{{- if (or .DbMySql (and .DbPostgres .DbPostgres.AuthUsingManagedIdentity))}}
+{{- if (or (and .DbMySql .DbMySql.AuthUsingManagedIdentity) (and .DbPostgres .DbPostgres.AuthUsingManagedIdentity))}}
 
 resource linkerCreatorIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
   name: '${name}-linker-creator-identity'
@@ -292,28 +327,6 @@ resource linkerCreatorRole 'Microsoft.Authorization/roleAssignments@2022-04-01' 
       'Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')
     principalType: 'ServicePrincipal'
     principalId: linkerCreatorIdentity.properties.principalId
-  }
-}
-{{- end}}
-{{- if .DbMySql}}
-
-resource appLinkToMySql 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
-  dependsOn: [ linkerCreatorRole ]
-  name: '${name}-link-to-mysql'
-  location: location
-  kind: 'AzureCLI'
-  identity: {
-    type: 'UserAssigned'
-    userAssignedIdentities: {
-      '${linkerCreatorIdentity.id}': {}
-    }
-  }
-  properties: {
-    azCliVersion: '2.63.0'
-    timeout: 'PT10M'
-    scriptContent: 'apk update; apk add g++; apk add unixodbc-dev; az extension add --name containerapp; az extension add --name serviceconnector-passwordless --upgrade; az containerapp connection create mysql-flexible --connection appLinkToMySql --source-id ${app.id} --target-id ${mysqlDatabaseId} --client-type springBoot --user-identity client-id=${identity.properties.clientId} subs-id=${subscription().subscriptionId} user-object-id=${linkerCreatorIdentity.properties.principalId} mysql-identity-id=${mysqlIdentityName} -c main --yes;'
-    cleanupPreference: 'OnSuccess'
-    retentionInterval: 'P1D'
   }
 }
 {{- end}}
@@ -339,8 +352,30 @@ resource appLinkToPostgres 'Microsoft.Resources/deploymentScripts@2023-08-01' = 
   }
 }
 {{- end}}
+{{- if (and .DbMySql .DbMySql.AuthUsingManagedIdentity)}}
 
+resource appLinkToMySql 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
+  dependsOn: [ linkerCreatorRole ]
+  name: '${name}-link-to-mysql'
+  location: location
+  kind: 'AzureCLI'
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${linkerCreatorIdentity.id}': {}
+    }
+  }
+  properties: {
+    azCliVersion: '2.63.0'
+    timeout: 'PT10M'
+    scriptContent: 'apk update; apk add g++; apk add unixodbc-dev; az extension add --name containerapp; az extension add --name serviceconnector-passwordless --upgrade; az containerapp connection create mysql-flexible --connection appLinkToMySql --source-id ${app.id} --target-id ${mysqlDatabaseId} --client-type springBoot --user-identity client-id=${identity.properties.clientId} subs-id=${subscription().subscriptionId} user-object-id=${linkerCreatorIdentity.properties.principalId} mysql-identity-id=${mysqlIdentityName} -c main --yes;'
+    cleanupPreference: 'OnSuccess'
+    retentionInterval: 'P1D'
+  }
+}
+{{- end}}
 {{- if (and .AzureServiceBus .AzureServiceBus.AuthUsingManagedIdentity) }}
+
 resource servicebus 'Microsoft.ServiceBus/namespaces@2022-01-01-preview' existing = {
   name: azureServiceBusNamespace
 }
@@ -364,7 +399,6 @@ resource serviceBusSenderRoleAssignment 'Microsoft.Authorization/roleAssignments
     principalType: 'ServicePrincipal'
   }
 }
-
 {{end}}
 
 output defaultDomain string = containerAppsEnvironment.properties.defaultDomain

--- a/cli/azd/resources/scaffold/templates/main.bicept
+++ b/cli/azd/resources/scaffold/templates/main.bicept
@@ -188,9 +188,15 @@ module {{bicepName .Name}} './app/{{.Name}}.bicep' = {
     postgresDatabaseUser: postgresDb.outputs.databaseUser
     postgresDatabasePassword: vault.getSecret(postgresDb.outputs.databaseConnectionKey)
     {{- end}}
-    {{- if .DbMySql}}
+    {{- if (and .DbMySql .DbMySql.AuthUsingManagedIdentity)}}
     mysqlDatabaseId: mysqlDb.outputs.databaseId
     mysqlIdentityName: mysqlDb.outputs.identityName
+    {{- end}}
+    {{- if (and .DbMySql .DbMySql.AuthUsingUsernamePassword)}}
+    mysqlDatabaseHost: mysqlDb.outputs.databaseHost
+    mysqlDatabaseName: mysqlDb.outputs.databaseName
+    mysqlDatabaseUser: mysqlDb.outputs.databaseUser
+    mysqlDatabasePassword: vault.getSecret(mysqlDb.outputs.databaseConnectionKey)
     {{- end}}
     {{- if (and .AzureServiceBus .AzureServiceBus.AuthUsingConnectionString)}}
     azureServiceBusConnectionString: vault.getSecret(serviceBus.outputs.serviceBusConnectionStringKey)

--- a/cli/azd/resources/scaffold/templates/main.bicept
+++ b/cli/azd/resources/scaffold/templates/main.bicept
@@ -91,7 +91,7 @@ module appsEnv './shared/apps-env.bicep' = {
   }
   scope: rg
 }
-{{- if (or (or (or .DbCosmosMongo .DbPostgres) .DbMySql) (and .AzureServiceBus .AzureServiceBus.AuthUsingConnectionString))}})))}}
+{{- if (or (or (or .DbCosmosMongo .DbPostgres) .DbMySql) (and .AzureServiceBus .AzureServiceBus.AuthUsingConnectionString))}}
 
 resource vault 'Microsoft.KeyVault/vaults@2022-07-01' existing = {
   name: keyVault.outputs.name
@@ -179,11 +179,13 @@ module {{bicepName .Name}} './app/{{.Name}}.bicep' = {
     {{- if .DbCosmosMongo}}
     cosmosDbConnectionString: vault.getSecret(cosmosDb.outputs.connectionStringKey)
     {{- end}}
-    {{- if .DbPostgres}}
-    postgresDatabaseName: postgresDb.outputs.databaseName
-    postgresDatabaseHost: postgresDb.outputs.databaseHost
-    postgresDatabaseUser: postgresDb.outputs.databaseUser
+    {{- if (and .DbPostgres .DbPostgres.AuthUsingManagedIdentity)}}
     postgresDatabaseId: postgresDb.outputs.databaseId
+    {{- end}}
+    {{- if (and .DbPostgres .DbPostgres.AuthUsingUsernamePassword)}}
+    postgresDatabaseHost: postgresDb.outputs.databaseHost
+    postgresDatabaseName: postgresDb.outputs.databaseName
+    postgresDatabaseUser: postgresDb.outputs.databaseUser
     postgresDatabasePassword: vault.getSecret(postgresDb.outputs.databaseConnectionKey)
     {{- end}}
     {{- if .DbMySql}}


### PR DESCRIPTION
Support both password and passwordless auth type for PostgreSQL and MySQL

Project used to verify this PR:
1. https://github.com/rujche/spring-petclinic/tree/rujche/use-mysql-support-both-password-and-passwordless
2. https://github.com/rujche/spring-petclinic/tree/rujche/use-postgresql-support-both-password-and-passwordless