### PR TITLE
Implement feature: detect redis by analyzing pom file

### DIFF
--- a/cli/azd/internal/appdetect/javaanalyze/project_analyzer_java.go
+++ b/cli/azd/internal/appdetect/javaanalyze/project_analyzer_java.go
@@ -14,6 +14,7 @@ func Analyze(path string) []AzureYaml {
 		&ruleMysql{},
 		&rulePostgresql{},
 		&ruleMongo{},
+		&ruleRedis{},
 		&ruleStorage{},
 		&ruleServiceBusScsb{},
 	}

--- a/cli/azd/internal/appdetect/javaanalyze/rule_redis.go
+++ b/cli/azd/internal/appdetect/javaanalyze/rule_redis.go
@@ -4,6 +4,16 @@ type ruleRedis struct {
 }
 
 func (r *ruleRedis) match(javaProject *javaProject) bool {
+	if javaProject.mavenProject.Dependencies != nil {
+		for _, dep := range javaProject.mavenProject.Dependencies {
+			if dep.GroupId == "org.springframework.boot" && dep.ArtifactId == "spring-boot-starter-data-redis" {
+				return true
+			}
+			if dep.GroupId == "org.springframework.boot" && dep.ArtifactId == "spring-boot-starter-data-redis-reactive" {
+				return true
+			}
+		}
+	}
 	return false
 }
 


### PR DESCRIPTION
Implement feature: detect redis by analyzing pom file.

## 1. Link to sample project.

https://github.com/rujche/samples/tree/azd-enhancemeng-for-redis

## 2. Make sure all redis related feature in spring-boot are included in this PR.

Search `redis` in this page: https://repo1.maven.org/maven2/org/springframework/boot/ We can got 4 artifacts:

1. **spring-boot-sample-data-redis-archetype**. Ignore this because it's an archetype.
2. **spring-boot-starter-data-redis**. Included in this PR.
3. **spring-boot-starter-data-redis-reactive**. Included in this PR.
4. **spring-boot-starter-redis**. Ignore this because the max version is 1.4.4, it's released on 2017-06-08)

Search `redis` in `spring-configuration-metadata.json`:
> ![image](https://github.com/user-attachments/assets/29825ec0-f3c2-4bfc-8372-3c4b7535b7c4)

There are 4 groups:
1. **spring.cache.redis**. Confirmed that the redis used in spring cache is using the **RedisConnectionFactory** configured by **spring.data.redis**.
2. **spring.data.redis**. Included in the sample project.
3. **spring.session.redis**. Confirmed that the redis used in spring session is using the **RedisConnectionFactory** configured by **spring.data.redis**.
4. **spring.redis**. Confirmed that this has been replaced by **spring.data.redis**.