### PR TITLE
Detect Mongo DB by dependency spring-boot-starter-data-mongodb-reactive just like spring-boot-starter-data-mongodb

### DIFF
--- a/cli/azd/internal/appdetect/javaanalyze/rule_mongo.go
+++ b/cli/azd/internal/appdetect/javaanalyze/rule_mongo.go
@@ -9,6 +9,9 @@ func (mr *ruleMongo) match(javaProject *javaProject) bool {
 			if dep.GroupId == "org.springframework.boot" && dep.ArtifactId == "spring-boot-starter-data-mongodb" {
 				return true
 			}
+			if dep.GroupId == "org.springframework.boot" && dep.ArtifactId == "spring-boot-starter-data-mongodb-reactive" {
+				return true
+			}
 		}
 	}
 	return false


### PR DESCRIPTION
Detect Mongo DB by dependency **spring-boot-starter-data-mongodb-reactive** just like **spring-boot-starter-data-mongodb**.

Confirmed that the properties with prefix **spring.data.mongodb** are shared in **spring-boot-starter-data-mongodb-reactive** and **spring-boot-starter-data-mongodb**. Here is the screenshot of related auto configuration:

> ![image](https://github.com/user-attachments/assets/86344875-ba94-436c-b291-0f6726684ee0)
